### PR TITLE
Use StringArrayData to modify string

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .vs/
+.idea/
 obj/
 bin/
 *.user

--- a/Paggles/Plugin.cs
+++ b/Paggles/Plugin.cs
@@ -1,8 +1,4 @@
-using Dalamud.Game.Command;
-using Dalamud.IoC;
 using Dalamud.Plugin;
-using System.IO;
-using Dalamud.Interface.Windowing;
 using Dalamud.Plugin.Services;
 using Dalamud.Game.Addon.Lifecycle;
 using Dalamud.Game.Addon.Lifecycle.AddonArgTypes;

--- a/Paggles/Plugin.cs
+++ b/Paggles/Plugin.cs
@@ -2,6 +2,7 @@ using Dalamud.Plugin;
 using Dalamud.Plugin.Services;
 using Dalamud.Game.Addon.Lifecycle;
 using Dalamud.Game.Addon.Lifecycle.AddonArgTypes;
+using Dalamud.Memory;
 using FFXIVClientStructs.FFXIV.Component.GUI;
 
 namespace Paggles
@@ -10,45 +11,30 @@ namespace Paggles
     {
         private IAddonLifecycle AddonLifecycle { get; init; }
 
-        private float? original = null;
-
         public Plugin(IAddonLifecycle addonLifecycle)
         {
             this.AddonLifecycle = addonLifecycle;
-
-            AddonLifecycle.RegisterListener(AddonEvent.PreSetup, "_DTR", ResetPaggles);
-            AddonLifecycle.RegisterListener(AddonEvent.PostRequestedUpdate, "_DTR", PagglesTime);
+            AddonLifecycle.RegisterListener(AddonEvent.PreRequestedUpdate, "_DTR", PagglesTime);
         }
 
         public void Dispose()
         {
-            AddonLifecycle.UnregisterListener(ResetPaggles);
             AddonLifecycle.UnregisterListener(PagglesTime);
-        }
-
-        public void ResetPaggles(AddonEvent type, AddonArgs args)
-        {
-            original = null;
         }
 
         public unsafe void PagglesTime(AddonEvent type, AddonArgs args)
         {
-            AtkUnitBase* dtrButtonBase = (AtkUnitBase*)args.Addon;
-            AtkComponentButton* dtrTimeButton = dtrButtonBase->GetButtonNodeById(16);
-            AtkTextNode *textNode = dtrTimeButton->ButtonTextNode;
+            if (args is not AddonRequestedUpdateArgs updateArgs) return;
 
-            string originalText = textNode->NodeText.ToString();
+            const int stringArrayNum = 67;
+            const int stringNum = 2;
+
+            StringArrayData* strArray = *(StringArrayData**) (updateArgs.StringArrayData + (8 * stringArrayNum));
+            string originalText = MemoryHelper.ReadStringNullTerminated((nint) strArray->ManagedStringArray[stringNum]);
             originalText = originalText.Replace("a.m.", "aggles");
             originalText = originalText.Replace("p.m.", "paggles");
 
-            textNode->SetText(originalText);
-            textNode->ResizeNodeForCurrentText();
-
-            if (original is null)
-                original = dtrButtonBase->RootNode->X;
-
-            float diff = dtrButtonBase->RootNode->Width - textNode->AtkResNode.Width;
-            dtrButtonBase->RootNode->X = (float)(original + diff);
+            strArray->SetValue(stringNum, originalText, false, true, true);
         }
     }
 }


### PR DESCRIPTION
FFXIV uses an array of arrays of strings for UI elements called StringArrayData. This can be easily viewed in `/tweaks Debug`'s "Array Data" tab. By searching `p.m.`, we can find that String Array #067 contains the clock time in string #02.

By looking at the decompilation of `Client::UI::AddonDTR_OnRequestedUpdate`, we can see a `stringArrayData = *(a3 + 0x218);`. 0x218 is 536, which is 8 * 67 (which matches our observation of string array #067, and confirms that a3 matches the delegate [here](https://github.com/goatcorp/Dalamud/blob/7ee20272deb187908c2b4d3d4a837a7127f7abf4/Dalamud/Game/Addon/Lifecycle/AddonLifecycle.cs#L77)).

This variable is then passed to `sub_14115D680`, where we can see `*(*(stringArrayData + 0x20) + 16i64)`. 0x20 matches our field on the [StringArrayData](https://github.com/aers/FFXIVClientStructs/blob/ac2ced26fc98153c65f5b8f0eaf0f464258ff683/FFXIVClientStructs/FFXIV/Component/GUI/StringArrayData.cs#L6) struct, and the 16 matches to our observation of string #02.

We can then retrieve this value, Paggles it Up™, and set it. It seems to result in increased update calls, but it does not seem to impact performance (at least on my machine).

The benefit of doing this means that the OnRequestedUpdate function calculates its width properly, meaning that all logic relating to fixing the width can be dropped for a 100% reliable method.